### PR TITLE
Display dataset filename when loading from CSV/TSV/JSON data or Vega-Lite spec in Voyager-Electron

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,10 +40,13 @@ const handlers = {
     dialog.showOpenDialog(mainWindow, options, (filenames) => {
       if (filenames && filenames.length > 0) {
         const fp = filenames[0];
+
+        const filename = fp.replace(/^.*[\\\/]/, '');
+
         // TODO Send 'loading' signal/message to renderer thread.
         const data = loadData.load(fp);
         if (RENDERER_READY) {
-          mainWindow.webContents.send('data', data);
+          mainWindow.webContents.send('data', data, filename);
         } else {
           // This may be overkill.
           dataQueue.push(data);
@@ -70,8 +73,9 @@ const handlers = {
         const spec = loadData.loadJSON(fp);
 
         // Here is where you can manipulate the spec and resolve any relative path issues.
+        const filename = fp.replace(/^.*[\\\/]/, '');
 
-        mainWindow.webContents.send('spec', spec);
+        mainWindow.webContents.send('spec', spec, filename);
       }
     });
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "d3-dsv": "^1.0.5",
-    "datavoyager": "^2.0.0-alpha.9",
+    "datavoyager": "^2.0.0-alpha.11",
     "datavoyager-server": "git://github.com/vega/voyager-server.git",
     "electron-debug": "^1.1.0",
     "jschardet": "^1.4.2"

--- a/renderer.js
+++ b/renderer.js
@@ -10,9 +10,8 @@ const config = {
   showDataSourceSelector: false,
   serverUrl,
 };
-let data;
 
-const voyagerInstance = libVoyager.CreateVoyager('#voyager-embed', config, data);
+const voyagerInstance = libVoyager.CreateVoyager('#voyager-embed', config, undefined);
 
 setTimeout(() => {
   // Tell main thread we are ready.
@@ -21,15 +20,16 @@ setTimeout(() => {
 
 
 // Handle data updates
-ipcRenderer.on('data', (event, arg) => {
-  data = arg;
+ipcRenderer.on('data', (event, data, filename) => {
+  voyagerInstance.setFilename(filename);
   voyagerInstance.updateData({
     values: data,
   });
 });
 
 // Handle spec updates
-ipcRenderer.on('spec', (event, spec) => {
+ipcRenderer.on('spec', (event, spec, filename) => {
+  voyagerInstance.setFilename(filename);
   voyagerInstance.setSpec(spec);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,9 +4219,9 @@ vega-datasets@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/vega-datasets/-/vega-datasets-1.8.0.tgz#a614ca655164e4f1a5e4477864d1091350d4eac8"
 
-"vega-datasets@github:vega/vega-datasets#gh-pages":
-  version "1.8.0"
-  resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/26bddc53d6112cff239436cdc85f56249c39e9e0"
+vega-datasets@vega/vega-datasets#gh-pages:
+  version "1.10.0"
+  resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/7080ba8297825d27495bdfb8386d10cff83cbacf"
 
 vega-encode@1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,10 @@
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.39.tgz#8aced4196387038113f6f9aa4014ab4c51edab3c"
 
+"@types/react@>=15":
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.5.tgz#d713cf67cc211dea20463d2a0b66005c22070c4b"
+
 accepts@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
@@ -54,6 +58,12 @@ acorn@^3.0.4:
 acorn@^5.0.0, acorn@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
+
+add-dom-event-listener@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
+  dependencies:
+    object-assign "4.x"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -206,6 +216,13 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+babel-runtime@6.x, babel-runtime@^6.9.2:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 balanced-match@^0.4.2:
   version "0.4.2"
@@ -413,7 +430,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.0:
+classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -520,6 +537,14 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
 
+compassql@0.19.15:
+  version "0.19.15"
+  resolved "https://registry.yarnpkg.com/compassql/-/compassql-0.19.15.tgz#6e3fbe8d107352c5f89d526b655c1215b9ae0444"
+  dependencies:
+    datalib "~1.7.0"
+    typescript-json-schema "^0.9.0"
+    vega-lite "2.0.0-beta.14"
+
 compassql@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/compassql/-/compassql-0.19.0.tgz#83f1784eece8fdc42910742d96a73afc84312d5e"
@@ -527,6 +552,16 @@ compassql@^0.19.0:
     datalib "~1.7.0"
     typescript-json-schema "^0.9.0"
     vega-lite "2.0.0-beta.10"
+
+component-classes@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
+  dependencies:
+    component-indexof "0.0.3"
+
+component-indexof@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -588,6 +623,10 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+core-js@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -605,7 +644,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-react-class@^15.5.3, create-react-class@^15.6.0:
+create-react-class@15.x, create-react-class@^15.5.3, create-react-class@^15.5.x, create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
@@ -630,6 +669,13 @@ cryptiles@2.x.x:
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
+css-animation@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-animation/-/css-animation-1.4.1.tgz#5b8813125de0fbbbb0bbe1b472ae84221469b7a8"
+  dependencies:
+    babel-runtime "6.x"
+    component-classes "^1.2.5"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -952,7 +998,47 @@ datalib@~1.7.0:
     morgan "^1.7.0"
     vega-lite "^2.0.0-beta.10"
 
-datavoyager@^2.0.0-alpha.8, datavoyager@^2.0.0-alpha.9:
+datavoyager@^2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/datavoyager/-/datavoyager-2.0.0-alpha.11.tgz#2830356e0019015404d17231252d9ad7f7eb7dd5"
+  dependencies:
+    ajv "^5.2.2"
+    compassql "0.19.15"
+    font-awesome "^4.7.0"
+    font-awesome-sass-loader "^1.0.3"
+    isomorphic-fetch "^2.2.1"
+    moment "^2.18.1"
+    normalize-scss "^6.0.0"
+    papaparse "^4.3.5"
+    rc-slider "^8.2.0"
+    re-reselect "0.6.2"
+    react "^15.4.2"
+    react-copy-to-clipboard "^5.0.0"
+    react-css-modules "^4.1.0"
+    react-datetime "^2.8.10"
+    react-dnd "^2.2.3"
+    react-dnd-html5-backend "^2.2.3"
+    react-dom "^15.4.2"
+    react-file-download "^0.3.4"
+    react-modal "^2.0.6"
+    react-redux "^5.0.2"
+    react-split-pane "^0.1.58"
+    react-tabs "^1.1.0"
+    react-tether "^0.5.6"
+    redux "^3.6.0"
+    redux-action-log "^2.0.1"
+    redux-logger "^3.0.6"
+    redux-thunk "^2.2.0"
+    redux-undo "1.0.0-beta9-9-6"
+    reselect "^2.5.4"
+    tether "^1.4.0"
+    tslib "^1.5.0"
+    vega "3.0.0-rc2"
+    vega-datasets "^1.8.0"
+    vega-lite "2.0.0-beta.14"
+    vega-tooltip "^0.4.2"
+
+datavoyager@^2.0.0-alpha.8:
   version "2.0.0-alpha.9"
   resolved "https://registry.yarnpkg.com/datavoyager/-/datavoyager-2.0.0-alpha.9.tgz#da1b36409452ed8f9003512557d334e21c35053d"
   dependencies:
@@ -1075,6 +1161,10 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+dom-align@1.x:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.6.4.tgz#7702a40352ebf29f31551296756d08dae2b3c3fa"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -2361,6 +2451,10 @@ lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
@@ -2372,6 +2466,22 @@ lodash.camelcase@^4.3.0:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.keys@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -2523,6 +2633,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
 morgan@^1.7.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.8.2.tgz#784ac7734e4a453a9c6e6e8680a9329275c8b687"
@@ -2626,9 +2740,13 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.x, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-inspect@~0.4.0:
   version "0.4.0"
@@ -2731,6 +2849,10 @@ package-json@^4.0.0:
     registry-auth-token "^3.0.1"
     registry-url "^3.0.3"
     semver "^5.1.0"
+
+papaparse@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.3.5.tgz#b6cdf5cae6fe9ec603b1be66f114a63ac645a036"
 
 parse-color@^1.0.0:
   version "1.0.0"
@@ -3132,7 +3254,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -3196,6 +3318,61 @@ raw-body@~2.2.0:
     iconv-lite "0.4.15"
     unpipe "1.0.0"
 
+rc-align@2.x:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.3.4.tgz#d83bdab7560f0142e72a3de1d495dab6ba225249"
+  dependencies:
+    dom-align "1.x"
+    prop-types "^15.5.8"
+    rc-util "4.x"
+
+rc-animate@2.x:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.4.1.tgz#df3e0f56fe106afe4bf52ff408ced241c5178919"
+  dependencies:
+    babel-runtime "6.x"
+    css-animation "^1.3.2"
+    prop-types "15.x"
+
+rc-slider@^8.2.0:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.3.1.tgz#b64d66ca1d1b755e4b411ca10906767180a7aeff"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    prop-types "^15.5.4"
+    rc-tooltip "^3.4.2"
+    rc-util "^4.0.4"
+    shallowequal "^1.0.1"
+    warning "^3.0.0"
+
+rc-tooltip@^3.4.2:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.4.8.tgz#4a422374f57f3b00f4d04941863850ceddd24c56"
+  dependencies:
+    babel-runtime "6.x"
+    prop-types "^15.5.8"
+    rc-trigger "1.x"
+
+rc-trigger@1.x:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-1.11.3.tgz#47b8b58e0863c2277e367b86f1cfa29eb612db56"
+  dependencies:
+    babel-runtime "6.x"
+    create-react-class "15.x"
+    prop-types "15.x"
+    rc-align "2.x"
+    rc-animate "2.x"
+    rc-util "4.x"
+
+rc-util@4.x, rc-util@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.4.tgz#99813dd90aee7e29b64939a70ac176ead3f4ff39"
+  dependencies:
+    add-dom-event-listener "1.x"
+    babel-runtime "6.x"
+    shallowequal "^0.2.2"
+
 rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
@@ -3204,6 +3381,10 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.1:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+re-reselect@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/re-reselect/-/re-reselect-0.6.2.tgz#07c3856b8cc17916c27f13f707f10263a1d4d21b"
 
 react-copy-to-clipboard@^5.0.0:
   version "5.0.0"
@@ -3219,6 +3400,15 @@ react-css-modules@^4.1.0:
     hoist-non-react-statics "^1.2.0"
     lodash "^4.16.6"
     object-unfreeze "^1.1.0"
+
+react-datetime@^2.8.10:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.9.0.tgz#9ec80060cbb8e5c5d8f98f0acebb6f4712ce449a"
+  dependencies:
+    "@types/react" ">=15"
+    object-assign "^3.0.0"
+    prop-types "^15.5.7"
+    react-onclickoutside "^5.9.0"
 
 react-dnd-html5-backend@^2.2.3:
   version "2.4.1"
@@ -3250,6 +3440,10 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-file-download@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/react-file-download/-/react-file-download-0.3.4.tgz#4e1cfc7a47df6eeb299dfd845b99676cdedab5d2"
+
 react-modal@^2.0.6:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-2.2.2.tgz#4bbf98bc506e61c446c9f57329c7a488ea7d504b"
@@ -3257,6 +3451,12 @@ react-modal@^2.0.6:
     exenv "1.2.0"
     prop-types "^15.5.10"
     react-dom-factories "^1.0.0"
+
+react-onclickoutside@^5.9.0:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz#00314e52567cf55faba94cabbacd119619070623"
+  dependencies:
+    create-react-class "^15.5.x"
 
 react-redux@^5.0.2:
   version "5.0.5"
@@ -3412,6 +3612,12 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-action-log@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/redux-action-log/-/redux-action-log-2.0.1.tgz#bd76d48b975bec98677f4d7b0c2f1452a6414557"
+  dependencies:
+    babel-runtime "^6.9.2"
+
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -3422,7 +3628,7 @@ redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
-redux-undo@beta:
+redux-undo@1.0.0-beta9-9-6, redux-undo@beta:
   version "1.0.0-beta9-9-6"
   resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.0-beta9-9-6.tgz#4bfd591b3e46b37c19eb7309766d7f020b2403e8"
 
@@ -3438,6 +3644,10 @@ redux@^3.2.0, redux@^3.6.0:
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -3650,6 +3860,16 @@ shallow-clone@^0.1.2:
 shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  dependencies:
+    lodash.keys "^3.1.2"
+
+shallowequal@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shapefile@0.3:
   version "0.3.1"
@@ -4215,11 +4435,7 @@ vega-dataflow@2:
     vega-statistics "1"
     vega-util "^1.4"
 
-vega-datasets@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/vega-datasets/-/vega-datasets-1.8.0.tgz#a614ca655164e4f1a5e4477864d1091350d4eac8"
-
-vega-datasets@vega/vega-datasets#gh-pages:
+vega-datasets@^1.8.0, vega-datasets@vega/vega-datasets#gh-pages:
   version "1.10.0"
   resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/7080ba8297825d27495bdfb8386d10cff83cbacf"
 
@@ -4279,6 +4495,16 @@ vega-lite@2.0.0-beta.10, vega-lite@^2.0.0-beta.10, vega-lite@^2.0.0-beta.3:
     tslib "^1.7.1"
     vega-event-selector "^2.0.0"
     vega-util "^1.4.1"
+    yargs "^8.0.2"
+
+vega-lite@2.0.0-beta.14:
+  version "2.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.0.0-beta.14.tgz#a643e0a528806106bc6234c4c48c9de6bd545225"
+  dependencies:
+    json-stable-stringify "^1.0.1"
+    tslib "^1.7.1"
+    vega-event-selector "^2.0.0"
+    vega-util "^1.5.0"
     yargs "^8.0.2"
 
 vega-loader@2:
@@ -4353,6 +4579,10 @@ vega-util@1, vega-util@^1.1, vega-util@^1.2, vega-util@^1.4, vega-util@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.4.1.tgz#3c5bea971aecec552786c190421f87e42165d666"
 
+vega-util@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.5.0.tgz#05fcec83557be38de5328b54ad2a7a0597740cc0"
+
 vega-view@1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-1.2.4.tgz#d3094cf841e5d91a1b3f630acec1400ab04c579a"
@@ -4420,6 +4650,12 @@ verror@1.3.6:
 viewport-dimensions@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz#de740747db5387fd1725f5175e91bac76afdf36c"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"


### PR DESCRIPTION
Fix #18
- Send filename with data or Vega-Lite spec to DataVoyager


Data pane now looks like this when loading from Vega-Lite spec:

![image](https://user-images.githubusercontent.com/17525561/29182695-b73fe8c8-7db4-11e7-9ac7-85ea0725912a.png)

and like this when loading from CSV (and TSV and JSON):

![image](https://user-images.githubusercontent.com/17525561/29182740-da3f2c08-7db4-11e7-9aa1-c36ca1ab09d7.png)
